### PR TITLE
Remove python2 legacy Queue import

### DIFF
--- a/app/cesium_web_server.py
+++ b/app/cesium_web_server.py
@@ -10,11 +10,7 @@ import tornado.websocket
 import tornado.httpserver
 import logging
                 
-import os, json, sys, select, signal, threading
-try:
-    import Queue as queue
-except ImportError:
-    import queue
+import os, json, queue, sys, select, signal, threading 
 
 lock = threading.Lock()
 live_web_sockets = set()


### PR DESCRIPTION
The python3 standard library uses `queue` as the module name now.