### PR TITLE
Module load failure no fenceitem

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -131,7 +131,7 @@ class CesiumModule(mp_module.MPModule):
     def send_fence(self):
         '''load and draw the fence in cesium'''
         self.fence = {}
-        self.fence_points_to_send = self.mpstate.public_modules['fence'].fenceloader.points
+        self.fence_points_to_send = self.mpstate.public_modules['fence'].wploader.points
         for point in self.fence_points_to_send:
             point_dict = point.to_dict()
             idx = point_dict['idx']
@@ -190,8 +190,8 @@ class CesiumModule(mp_module.MPModule):
             self.rally_change_time = time.time()
     
         # if the fence has changed, redisplay
-        if self.fence_change_time != self.module('fence').fenceloader.last_change:
-            self.fence_change_time = self.module('fence').fenceloader.last_change
+        if self.fence_change_time != self.module('fence').wploader.last_change:
+            self.fence_change_time = self.module('fence').wploader.last_change
             self.send_fence()
                 
     def idle_task(self):


### PR DESCRIPTION
# Expectation

In mavproxy, you can now use `module load cesium` and it receives data. This regressed when MAVProxy broke ABI and removed the `fenceloader` object from the default `fence` module.

You can also try:
```
./Tools/autotest/sim_vehicle.py  -v plane  -m "--load-module=cesium"
```

Previous behavior for `python3 cesium_web_server.py` should still work (if you are already running SITL).. ctrl+C takes a bit sometimes to complete. The patch I hacked in was too aggressive and had numerous errors.

Although the fence display no longer throws, it still doesn't yet work. That's ok. I'll fix that later.

# Issue

Closes #1 