### PR TITLE
Fence circle inclusions

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -234,6 +234,7 @@ class CesiumModule(mp_module.MPModule):
                 self.mpstate.functions.process_stdin('fence list')
 
             elif 'fence_clear' in payload.keys():
+                # Drop the payload value; it doesn't matter.
                 self.mpstate.functions.process_stdin('fence clear')
              
             else:

--- a/__init__.py
+++ b/__init__.py
@@ -51,7 +51,6 @@ class CesiumModule(mp_module.MPModule):
         self.aircraft = {'lat':None, 'lon':None, 'alt_wgs84':None,
                          'roll':None, 'pitch':None, 'yaw':None}
         self.pos_target = {'lat':None, 'lon':None, 'alt_wgs84':None}
-        self.fence = {}
         self.mission = {}
         
         self.server_thread = None
@@ -129,16 +128,18 @@ class CesiumModule(mp_module.MPModule):
 
 
     def send_fence(self):
-        '''load and draw the fence in cesium'''
-        self.fence = {}
-        self.fence_points_to_send = self.mpstate.public_modules['fence'].wploader.points
-        for point in self.fence_points_to_send:
-            point_dict = point.to_dict()
-            idx = point_dict['idx']
-            del point_dict['idx']
-            if idx != 0: # dont include the return location
-                self.fence[idx] = point_dict
-        self.send_data({"fence_data":self.fence})
+        '''load and draw the fence in cesium.
+        
+        This transforms the mission items into a dict keyed by index.
+        '''
+        wploader = self.mpstate.public_modules['fence'].wploader
+        fence = dict()
+        for point in [point.to_dict() for point in wploader.wpoints]:
+            idx = point['seq']
+            del point['seq']
+            fence[idx] = point
+        self.send_data({"fence_data": fence})
+
             
     def send_mission(self):
         '''load and draw the mission in cesium'''
@@ -225,9 +226,11 @@ class CesiumModule(mp_module.MPModule):
                 self.mpstate.functions.process_stdin('wp remove %u' % int(payload['wp_remove']))
              
             elif 'wp_list' in payload.keys():
+                # Drop the payload value; it doesn't matter.
                 self.mpstate.functions.process_stdin('wp list')
                  
             elif 'fence_list' in payload.keys():
+                # Drop the payload value; it doesn't matter.
                 self.mpstate.functions.process_stdin('fence list')
 
             elif 'fence_clear' in payload.keys():

--- a/app/cesium_web_server.py
+++ b/app/cesium_web_server.py
@@ -67,7 +67,10 @@ class DefaultWebSocket(tornado.websocket.WebSocketHandler):
         live_web_sockets.add(self)
         lock.release()
      
-    def on_message(self, message):
+    def on_message(self, message: str):
+        # A callback for when a websocket message is received from the browser (front end).
+        # This is called from inside the base tornado websocket handler class.
+
         if self.configuration.APP_DEBUG:
             print("received websocket message: {0}".format(message))
         message = json.loads(message)
@@ -75,7 +78,6 @@ class DefaultWebSocket(tornado.websocket.WebSocketHandler):
             self.callback(message) # this sends it to the module.send_out_queue_data for further processing.
         else:
             print("no callback for message: {0}".format(message))
-        print(dir(self))
 
     def on_close(self):
         if self.configuration.APP_DEBUG:

--- a/app/static/DST/js/core.js
+++ b/app/static/DST/js/core.js
@@ -102,44 +102,16 @@ $(function () { // init tool tips and only show on hover
 			clear_fences();
 		}
         
-        stored_fence.points_3d = [];
-		stored_fence.points_2d = [];
-        
-        
         for (var idx in fence_data){
 			var fence_item = fence_data[idx];
 
 			if (fence_item.command != 5003) { // inclusion
-				console.warn("MISSION_ITEM is not supported: ", fence_item)
+				console.warn("MISSION_ITEM is not yet supported: ", fence_item)
 			}
-
-
-			var lat = fence_item.x; // degrees
-			var lng = fence_item.y; // degrees
-		
-			var pointOfInterest = Cesium.Cartographic.fromDegrees(
-				lng, lat, 5000, new Cesium.Cartographic()
-			);
 
 			draw_inclusion_circle(fence_item);
 
-			
-
-			// TODO build out different fence objects
-			// https://sandcastle.cesium.com/#c=nVRda9swFP0rIi91IJPihiwsTcNKBmUwWGFlL3UeFFlJxWTJSHKCV/rfd2XZrp0Yuo1AiI50dT50b5hW1qGj4Cdu0C1S/IQ23Ioiwz8rLEpGrFpvtHJUKG6S0fgmUaiuwYxm3FC8l+Wjjl78BkIpt04o6oRWy+a6DTUOflE1w3ujsy/8YDi30Yc4XuD44wTNrvEinqB4Pp1O8XQ88Te9eib/YZXKXMtSggTbF/pQwxstJWeeNPJ17WlM0zQoy7UVft+id2TdGUPL6Cm4OZPYBRcBvO6BnwI42wYTJ5G6ZyCcVyupdb5EzhQ8UbW9OkjLuOL4YHSh0gcjMlB6rMW3VsZvYTBhmOT9JDYVds91xp0pg2e41cHT/ts7BOWGpqLwWc39k9R6A/uh5gD+QW7MDKfuTUpQ6+sJed8vkBOCXvxh1FJ9BV6qoBmX6KnBtuHI60UuzeF+PvdnV4WEWi/LurgyL1JYXwXgqkKoc0bsCkgPdupOZ1pqH273ETx0znTX1EaQJHR5+zXF83HV6sPtkPeD6XrpB9e30mbVemoQTxN4CPkPisEHARIDg0fVoctDSGAi5GIS/S3tLP7tKPqigWHswp1x7MLNQHp025hvRGEmaZY/6mAW+sXP5s1oMlpZV0q+Du+M0GeR5do4VBgZYUwcz3IJHW7JrmC/uMPM2vC/iNCKdEtXqThCN90O/JEi4LYWdvaFlD/Eb56M1isC5y9KpYZZVIfvR24kLf2x53j9LYAY4xWB5XCl01ruqDm7+Q8
-
-			// TODO ensure field "mission_type" of MAV_MISSION_TYPE is MAV_MISSION_TYPE_FENCE.
-
-			// Sample the terrain (async)
-			// Cesium.sampleTerrainMostDetailed(viewer.terrainProvider, [ pointOfInterest ]).then(function(samples) {
-			// 	terrain_sample_height = samples[0].height
-			// });
-			// var fence_top_alt = stored_fence.alt_agl + terrain_sample_height
-			// stored_fence.points_3d.push(lng, lat, fence_top_alt); //[ lon, lat, alt, lon, lat, alt, etc. ]
-			stored_fence.points_2d.push(lng, lat); //[ lon, lat, lon, lat, etc. ]	
-
         };
-		draw_fence();
     }
 
 	function clear_fences() {
@@ -158,6 +130,13 @@ $(function () { // init tool tips and only show on hover
 		inclusionCircles.length = 0;
 	
 		console.log("All inclusion circles cleared.");
+	}
+
+	function toggle_fences() {
+		// Remove all circle primitives from the scene
+		inclusionCircles.forEach(circlePrimitive => {
+			circlePrimitive.show = !circlePrimitive.show;
+		});	
 	}
 
 	function draw_inclusion_circle(mission_item_circle) {
@@ -188,42 +167,6 @@ $(function () { // init tool tips and only show on hover
 
 		// Store the reference in the array
 		inclusionCircles.push(circlePrimitive);
-	};
-
-    function draw_fence() {
-		return
-		viewer.entities.remove(viewer.entities.getById('fence_wall'))
-		// TODO draw fence as dashed line if it's disabled.
-		// https://sandcastle.cesium.com/#c=5VXbjtowEP2VaZ4SiTpAl6plWVQE1WqlXlZa1Kpq+uBNBrDWsSPbIU0r/r1OghNgL93n9gk8PmfmzJnBxFJoA1uGBSq4AIEFzFGzPCVf6pgfeXF9nkthKBOoIq8HvyMBAAaVsqGxYyybM1kpmX6Viif7gB9EYhecRyKui+kYBdpaTVFSH+1lJNgK/Bf7XJdK5iK5lrzktui1YikzbIuE6Zs8y6QymPg1MwgaNQUTiSwI5aiMX8uDyHN8DVI4uUAVgpBWh0tUX26YhoxTs5IqJZFXZagk7yphYQguE1xyWUSiLk3WjUgnThOaJHXtAxsfacRvLIQ1yhSNKq+sM1RYq8dH5JNbx+p448drOXJHAsiktuXtGNqhzam1QDMqXtVzW+BaIeqZtar0v3dEgJeD4ZAMR6M3vcPo2WsyeDsa9e4hB/2/In8EB4eCJWYzhkGf9NvozgHaLzTLkKrKiqPGXcsfqR0yo3zWwrrm0/1d27kD130vywz9Ts0ppPXUTr+COuSJwJ3d9OD8dGUWVG/+x5Vp9uB569L/93alGvszdmX/DMY0RUUJl/Ju1jxgT7rtdz+y1i1rSN9a0qQ/6LjL4I9qRA+OP59QsrTO6OpN9Ls2Fft5Rq4W7z8tr5bfmnX3et5Em5Lj1HX7jqXV6wq54j4hocG0el1Rh7d5fIeGxFpX1Ao6CQ+pk4RtgSUXD/zxQMyp1vZmlXN+w35h5E0nocXfo3JJEybWn7eoOC0r2GYw/dAECSGT0B4fZhop+S1VJ5n/AA
-    	if (stored_fence.points_2d.length > 4) {
-
-			scene.groundPrimitives.add(
-				new Cesium.GroundPolylinePrimitive({
-					geometryInstances: new Cesium.GeometryInstance({
-						geometry: new Cesium.GroundPolylineGeometry({
-							positions: Cesium.Cartesian3.fromDegreesArray(
-							stored_fence.points_2d
-							),
-							width: 10.0,
-						}),
-					}),
-					appearance: new Cesium.PolylineMaterialAppearance({
-						material: Cesium.Material.fromType(
-							Cesium.Material.PolylineDashType
-							),
-					}),
-				})
-			);
-
-
-    		// var fence_wall = viewer.entities.add({
-		    // 	id : "fence_wall",
-		    // 	wall : {
-		    // 		positions: Cesium.Cartesian3.fromDegreesArrayHeights( stored_fence.points )
-		    // 	},
-		    // 	show : stored_fence.show
-			// })
-    	}
 	};
     
     function update_mission_data(mision_data) {

--- a/app/static/DST/js/settings.js
+++ b/app/static/DST/js/settings.js
@@ -24,8 +24,8 @@ $('#toggle_pos_target_line').on('click', function(event) {
 
 $('#toggle_fence').on('click', function(event) {
 	  event.preventDefault()
-	  fence.show = !fence.show
-	  draw_fence()
+	  inclusionCircles.length
+	  toggle_fences()
 });
 
 $('#send_auto').on('click', function(event) {

--- a/app/templates/settings_general.html
+++ b/app/templates/settings_general.html
@@ -10,7 +10,7 @@
  <a class="btn btn-secondary btn-block" id="toggle_pos_target_line">Toggle Target Line</a>
 </div>
 <div class="container" style="padding-top:15px;">
- <a class="btn btn-secondary btn-block" id="toggle_fence">Toggle Fence</a>
+ <a class="btn btn-secondary btn-block" id="toggle_fence">Toggle Fence Visibility</a>
 </div>
 <div class="container" style="padding-top:15px;">
  <a class="btn btn btn-outline-primary btn-block" id="send_auto">AUTO</a>


### PR DESCRIPTION
# Purpose

Implement MISSION_ITEM parsing for circle inclusion fences and remove dead code relating to the old fence item protocol.

# Details

I started out here implementing storage of fence circle inclusion items, which would have content like this:

```json
{
    "mavpackettype": "MISSION_ITEM",
    "target_system": 255,
    "target_component": 230,
    "frame": 0,
    "command": 5003,
    "current": 0,
    "autocontinue": 0,
    "param1": 123,
    "param2": 0,
    "param3": 0,
    "param4": 0,
    "x": -35.3630712,
    "y": 149.1649605,
    "z": 0,
    "mission_type": 1
}
```

* command 5003 is circle inclusion fence
* param1 is the radius of 123 meters
* x is the latitude (deg)
* y is the longitude (deg)

# Expectations for MAVCesium
* Display the fence when you click Fence->Show if it's in the autopilot
* Clear the fence when the fence gets cleared (from mavproxy map)
* Show/Hide will show/hide the existing fence. It's memory stays intact and is purely visual.

# Known issues

* We don't handle bootup of mavcesium requesting the fence automatically. You have to request fences listed. Same as mavproxy.

# Demo

![image](https://github.com/user-attachments/assets/3e62ab79-9528-42dc-b8d1-fc1443e50f48)

# Issue

Relates to #7 
